### PR TITLE
Set Pull Policy to Latest

### DIFF
--- a/Docker-Compose-Template/docker-compose-custom-ports-linux.yml
+++ b/Docker-Compose-Template/docker-compose-custom-ports-linux.yml
@@ -3,6 +3,7 @@ services:
   emulator:
     container_name: "eventhubs-emulator"
     image: "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest"
+    pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/Eventhubs_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
+++ b/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
@@ -3,6 +3,7 @@ services:
   emulator:
     container_name: "eventhubs-emulator"
     image: "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest"
+        pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/Eventhubs_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
+++ b/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
@@ -3,7 +3,7 @@ services:
   emulator:
     container_name: "eventhubs-emulator"
     image: "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest"
-  pull_policy: always
+    pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/Eventhubs_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
+++ b/Docker-Compose-Template/docker-compose-custom-ports-windows-mac.yml
@@ -3,7 +3,7 @@ services:
   emulator:
     container_name: "eventhubs-emulator"
     image: "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest"
-        pull_policy: always
+  pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/Eventhubs_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-default.yml
+++ b/Docker-Compose-Template/docker-compose-default.yml
@@ -3,6 +3,7 @@ services:
   emulator:
     container_name: "eventhubs-emulator"
     image: "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest"
+    pull_policy: always
     volumes:
       - "${CONFIG_PATH}:/Eventhubs_Emulator/ConfigFiles/Config.json"
     ports:

--- a/Docker-Compose-Template/docker-compose-with-containerized-app.yml
+++ b/Docker-Compose-Template/docker-compose-with-containerized-app.yml
@@ -9,6 +9,7 @@ services:
 
   emulator:
     image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest
+    pull_policy: always
     volumes:
       - "./Config.json:/Eventhubs_Emulator/ConfigFiles/Config.json"
     environment:


### PR DESCRIPTION
In case local image is present in cache with same name+tag, currently on executing the script we will not be fetching the latest image from repository even if image present in the upstream repository has been updated.
This PR addresses the problem by setting the pull policy to "always".